### PR TITLE
fix mxUrlConverter.prototype.convert behavior with vscode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   Fixes base URL (resolves [#53](https://github.com/hediet/vscode-drawio/issues/53) and [#74](https://github.com/hediet/vscode-drawio/issues/74)).
+-   Fixes base URL. Resolves [#53](https://github.com/hediet/vscode-drawio/issues/53) and [#74](https://github.com/hediet/vscode-drawio/issues/74). (Implemented by [Speedy37](https://github.com/Speedy37))
 
 ## [0.7.0] - 2020-06-11
 
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Ctrl-P is now forwarded to VS Code (fixes [#77](https://github.com/hediet/vscode-drawio/issues/77))
+-   Ctrl-P is now forwarded to VS Code. Resolves [#77](https://github.com/hediet/vscode-drawio/issues/77).
 
 ## [0.6.6] - 2020-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1-alpha.1]
+
+### Fixed
+
+-   Fixes base URL (resolves [#53](https://github.com/hediet/vscode-drawio/issues/53) and [#74](https://github.com/hediet/vscode-drawio/issues/74)).
+
 ## [0.7.0] - 2020-06-11
 
 ### Added

--- a/src/DrawioAppServer/DrawioWebviewInitializer.ts
+++ b/src/DrawioAppServer/DrawioWebviewInitializer.ts
@@ -95,9 +95,7 @@ export class DrawioWebviewInitializer {
 		webview: Webview
 	): string {
 		const vsuri = webview.asWebviewUri(
-			Uri.file(
-				path.join(__dirname, "../../drawio/src/main/webapp/index.html")
-			)
+			Uri.file(path.join(__dirname, "../../drawio/src/main/webapp"))
 		);
 		const customPluginsPath = webview.asWebviewUri(
 			// See webpack configuration.
@@ -108,7 +106,7 @@ export class DrawioWebviewInitializer {
 
 		// TODO use template engine
 		const patchedHtml = html
-			.replace("${vsuri}", vsuri.toString())
+			.replace(/\$\{vsuri\}/g, vsuri.toString())
 			.replace("${theme}", config.theme)
 			.replace("${lang}", config.language)
 			.replace("${chrome}", options.isReadOnly ? "0" : "1")

--- a/src/DrawioAppServer/vscode.html
+++ b/src/DrawioAppServer/vscode.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<base href="${vsuri}" />
+		<base href="${vsuri}/index.html" />
 		<script type="text/javascript">
 			var log;
 			(() => {
@@ -278,6 +278,18 @@
 						return old.apply(this, args);
 					};
 				});
+
+				// Fix mxUrlConverter.prototype.convert
+				// See https://github.com/jgraph/mxgraph/blob/master/javascript/src/js/util/mxUrlConverter.js for non minified version
+				mxUrlConverter.prototype.baseUrl = "${vsuri}/";
+				mxUrlConverter.prototype.updateBaseUrl = function () {
+					this.baseDomain = "${vsuri}";
+					this.baseUrl = "${vsuri}/";
+				};
+				const RX_IS_ABS_URL = /^(\/\/|[a-zA-Z][a-zA-Z\d+\-.]*:)/;
+				mxUrlConverter.prototype.isRelativeUrl = function (url) {
+					return url != null && !RX_IS_ABS_URL.test(url);
+				};
 
 				App.main();
 				console.log("drawio", window.Draw);

--- a/src/DrawioAppServer/vscode.html
+++ b/src/DrawioAppServer/vscode.html
@@ -279,17 +279,25 @@
 					};
 				});
 
-				// Fix mxUrlConverter.prototype.convert
-				// See https://github.com/jgraph/mxgraph/blob/master/javascript/src/js/util/mxUrlConverter.js for non minified version
-				mxUrlConverter.prototype.baseUrl = "${vsuri}/";
-				mxUrlConverter.prototype.updateBaseUrl = function () {
-					this.baseDomain = "${vsuri}";
-					this.baseUrl = "${vsuri}/";
-				};
-				const RX_IS_ABS_URL = /^(\/\/|[a-zA-Z][a-zA-Z\d+\-.]*:)/;
-				mxUrlConverter.prototype.isRelativeUrl = function (url) {
-					return url != null && !RX_IS_ABS_URL.test(url);
-				};
+				/**
+				 * See https://github.com/jgraph/mxgraph/blob/master/javascript/src/js/util/mxUrlConverter.js
+				 * for non minified version.
+				 * Fixes https://github.com/hediet/vscode-drawio/issues/53 and
+				 * https://github.com/hediet/vscode-drawio/issues/74.
+				 */
+				function fix_mxUrlConverter_prototype_convert() {
+					mxUrlConverter.prototype.baseUrl = "${vsuri}/";
+					mxUrlConverter.prototype.updateBaseUrl = function () {
+						this.baseDomain = "${vsuri}";
+						this.baseUrl = "${vsuri}/";
+					};
+					const RX_IS_ABS_URL = /^(\/\/|[a-zA-Z][a-zA-Z\d+\-.]*:)/;
+					mxUrlConverter.prototype.isRelativeUrl = function (url) {
+						return url != null && !RX_IS_ABS_URL.test(url);
+					};
+				}
+
+				fix_mxUrlConverter_prototype_convert();
 
 				App.main();
 				console.log("drawio", window.Draw);


### PR DESCRIPTION
This is done by doing 2 things:

fix isRelativeUrl : vscode use a custom protocol (i.e. vscode-resource://) which is not support by the current mxUrlConverter implementation.

fix baseUrl, relative urls are prefixed by baseUrl which is generated for protocol + host. Both protocol and host value are wrong in vscode context.

Resolves: #53
Resolves: #74 