### PR TITLE
fixed convert/export to unexpected path when filepath contains dot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3-alpha.1]
+
+### Fixed
+
+- Fixes export/convert output to wrong directory when filepath contains '.' . ([#117](https://github.com/hediet/vscode-drawio/pull/117),[@fatalc](https://github.com/fatalc))
+
 ## [0.7.2] - 2020-06-28
 
 ### Added


### PR DESCRIPTION
reproduce:

- open a file which path contains '.' like `github.com/foo/bar.dio.svg`
- do convert/export 
-  it saved file to wrong path `github.png` which expected save to `github.com/foo/bar.dio.png`