### PR TITLE
Fix webview error when data directory is symlink

### DIFF
--- a/src/DrawioWebviewInitializer/DrawioWebviewInitializer.ts
+++ b/src/DrawioWebviewInitializer/DrawioWebviewInitializer.ts
@@ -12,7 +12,8 @@ import { getDrawioExtensions } from "../DrawioExtensionApi";
 export class DrawioWebviewInitializer {
 	constructor(
 		private readonly config: Config,
-		private readonly log: OutputChannel
+		private readonly log: OutputChannel,
+		private readonly extensionPath: string
 	) {}
 
 	public async initializeWebview(
@@ -181,11 +182,11 @@ export class DrawioWebviewInitializer {
 		plugins: { jsCode: string }[]
 	): string {
 		const vsuri = webview.asWebviewUri(
-			Uri.file(path.join(__dirname, "../../drawio/src/main/webapp"))
+			Uri.file(path.join(this.extensionPath, "drawio/src/main/webapp"))
 		);
 		const customPluginsPath = webview.asWebviewUri(
 			// See webpack configuration.
-			Uri.file(path.join(__dirname, "../custom-drawio-plugins/index.js"))
+			Uri.file(path.join(this.extensionPath, "dist/custom-drawio-plugins/index.js"))
 		);
 
 		const localStorage = untracked(() => config.localStorage);

--- a/src/DrawioWebviewInitializer/DrawioWebviewInitializer.ts
+++ b/src/DrawioWebviewInitializer/DrawioWebviewInitializer.ts
@@ -186,7 +186,12 @@ export class DrawioWebviewInitializer {
 		);
 		const customPluginsPath = webview.asWebviewUri(
 			// See webpack configuration.
-			Uri.file(path.join(this.extensionPath, "dist/custom-drawio-plugins/index.js"))
+			Uri.file(
+				path.join(
+					this.extensionPath,
+					"dist/custom-drawio-plugins/index.js"
+				)
+			)
 		);
 
 		const localStorage = untracked(() => config.localStorage);

--- a/src/Extension.ts
+++ b/src/Extension.ts
@@ -41,7 +41,8 @@ export class Extension {
 	);
 	private readonly drawioWebviewInitializer = new DrawioWebviewInitializer(
 		this.config,
-		this.log
+		this.log,
+		this.context.extensionPath,
 	);
 
 	constructor(private readonly context: vscode.ExtensionContext) {

--- a/src/Extension.ts
+++ b/src/Extension.ts
@@ -42,7 +42,7 @@ export class Extension {
 	private readonly drawioWebviewInitializer = new DrawioWebviewInitializer(
 		this.config,
 		this.log,
-		this.context.extensionPath,
+		this.context.extensionPath
 	);
 
 	constructor(private readonly context: vscode.ExtensionContext) {


### PR DESCRIPTION
This attempts to fix #141, where .drawio files stuck at the loading screen when the VSCode data directory is a symlink.

@hediet I tested the vscode-pdf extension and it does not have this problem. Let's say the data directory is a symlink from `data` to `data1`. vscode-pdf is using URLs under `data`, resolved from [`context.extensionPath`](https://github.com/tomoki1207/vscode-pdfviewer/blob/95a4fed41db3d76a066deeeb2905ce13eff36e84/src/pdfPreview.ts#L102):

    vscode-webview-resource://{UUID}/file///{PATH}/data/extensions/tomoki1207.pdf-1.1.0/lib/build/pdf.js

while this extension is using URLs under `data1`, resolved from `__dirname`:

    vscode-webview-resource://{UUID}/file///{PATH}/data1/extensions/hediet.vscode-drawio-1.0.1/drawio/src/main/webapp/js/app.min.js 

I propose switching to `context.extensionPath` for the correct URL.

Please have a test again; I've only run `npm build`, replaced the index.js file and found it working.