### PR TITLE
Add new diagram command

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,10 @@
 		],
 		"commands": [
 			{
+				"command": "hediet.vscode-drawio.newDiagram",
+				"title": "Draw.io: New Diagram .."
+			},
+			{
 				"command": "hediet.vscode-drawio.convert",
 				"title": "Draw.io: Convert To..."
 			},

--- a/src/Extension.ts
+++ b/src/Extension.ts
@@ -46,26 +46,41 @@ export class Extension {
 
 	constructor(private readonly context: vscode.ExtensionContext) {
 		this.dispose.track(
-			vscode.commands.registerCommand("hediet.vscode-drawio.newDiagram", async () => {
-				const newFileName = await vscode.window.showInputBox({
-					placeHolder: 'Enter file name'
-				});
+			vscode.commands.registerCommand(
+				"hediet.vscode-drawio.newDiagram",
+				async () => {
+					const newFileName = await vscode.window.showInputBox({
+						placeHolder: "Enter file name",
+					});
 
-				if (newFileName) {
-					// Figure the folder to put new file
-					const openFilePath = vscode.window.activeTextEditor?.document.uri.path;
-					const activeFolderPath = openFilePath
-						? dirname(openFilePath)
-						: vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0].uri.path;
-					if (activeFolderPath) {
-						const fileUri = vscode.Uri.file(join(activeFolderPath, newFileName));
-						await vscode.workspace.fs.writeFile(fileUri, Buffer.of()); // write file with empty content
-						await vscode.commands.executeCommand('vscode.open', fileUri);
-					} else {
-						vscode.window.showErrorMessage("Failed to create new file. No active workspace found.");
+					if (newFileName) {
+						// Figure the folder to put new file
+						const openFilePath =
+							vscode.window.activeTextEditor?.document.uri.path;
+						const activeFolderPath = openFilePath
+							? dirname(openFilePath)
+							: vscode.workspace.workspaceFolders &&
+							  vscode.workspace.workspaceFolders[0].uri.path;
+						if (activeFolderPath) {
+							const fileUri = vscode.Uri.file(
+								join(activeFolderPath, newFileName)
+							);
+							await vscode.workspace.fs.writeFile(
+								fileUri,
+								Buffer.of()
+							); // write file with empty content
+							await vscode.commands.executeCommand(
+								"vscode.open",
+								fileUri
+							);
+						} else {
+							vscode.window.showErrorMessage(
+								"Failed to create new file. No active workspace found."
+							);
+						}
 					}
 				}
-			})
+			)
 		);
 
 		this.dispose.track(


### PR DESCRIPTION
Adds 'New diagram' option in command palette. It creates the new file in currently open file's folder or workspace folder.

## TODO
I noticed a corner/failing case when i tested locally - when there is a `.drawio` file open in editor the current open file path is `undefined` when i try to use `vscode.window.activeEditor.document.path`. Any ideas how to fix?

Fixes https://github.com/hediet/vscode-drawio/issues/145
Signed-off-by: Abhilash Gnan <abhilashgnan@gmail.com>