### PR TITLE
support extensionKind ui and workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
 	},
 	"readme": "./README.md",
 	"icon": "docs/logo.drawio.png",
+	"extensionKind": [
+		"ui",
+		"workspace"
+	],
 	"engines": {
 		"vscode": "^1.46.0"
 	},


### PR DESCRIPTION
### What

Indicate to VSCode that the extension can run in `ui` mode or in `workspace` mode.

### Why

When using VSCode with remote containers support VSCode can run extensions locally where the UI is being displayed or remotely where the files live. Most extension can run in either location, although some extension can only run on the ui side and some can only run on the workspace side.

When an extension doesn't indicate where it can be run it always runs at the workspace side.

The draw.io extension can run either on the UI or on the workspace. I've tested it locally and it works in both places. The advantage of changing this and indicating it can run in both places is that when using remote dev containers the developer doesn't have to manually install the extension in the container to use it.