### PR TITLE
remove redundant web extension kind definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
 	"icon": "docs/logo.drawio.png",
 	"extensionKind": [
 		"ui",
-		"workspace",
-		"web"
+		"workspace"
 	],
 	"engines": {
 		"vscode": "^1.46.0"


### PR DESCRIPTION
defining extension kind is not necessary if browser entry point is mentioned.