### PR TITLE
Use Memento for local storage config

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -419,7 +419,7 @@ export class DiagramConfig {
 
 	private migrateLocalStorageSettingsToMemento() {
 		const saved = this._localStorage.get();
-		if (!saved) {
+		if (!saved || Object.keys(saved).length === 0) {
 			return;
 		}
 		this.setLocalStorage(saved);


### PR DESCRIPTION
Fix #242 

In this PR we try to use Memento for the storage of configuration that we don't want the users to edit - previously they used to pollute the settings/preferences of the user.

This is just a starting point to discuss certain implementations and challenge/validate some assumptions.

1. I'm using the Memento of `globalState` (as opposed to `workspaceState`) - I'm looking for inputs here as I'm not sure how we use the local storage data (is it shared across diagrams, and the like), and I'm sure I'm not the right person to make this decision. Any context here would be great. I've made the assumption based on reading the code - it looked like we need only one key with a dependency on the extension id, so I assumed it's shared across all instances of the extension.
2. Since `globalState` inside `Config` is private, I've made the memento an explicit dependency of `DiagramConfig` (we need to pass an instance to construct) instead of trying to make it accessible like `config.globalState`. There are alternatives which we can discuss. The initial implementation is based on the assumption that this makes it extensible, makes the dependencies explicit, and segregates the interfaces in the process while not removing existing abstractions.
3. The memento updates are async, while our current setter is a synchronous API - `memento.update` returns a `Thenable<void>`. This is probably the biggest thing to discuss, as I would like to understand what we want to do here. There are several approaches each with its own merit, so it would be nice to know our intended direction. I'm happy to offer suggestions. With the code as it is now, the async update is fired but we don't wait for the updates to happen before we exit the method - this _can_ cause issues, but I'm not the best person to know how this affects us.
4. I'm assuming we can just return an empty record when we don't have anything saved - if there's a default we need to setup, we can add that.

I hope this is helpful as a starting point.
