### PR TITLE
mention the diagrams.net blog post to give users more confidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![](https://img.shields.io/static/v1?style=social&label=Donate&message=%E2%9D%A4&logo=Paypal&color&link=%3Curl%3E)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=ZP5F38L4C88UY&source=url)
 [![](https://img.shields.io/twitter/follow/hediet_dev.svg?style=social)](https://twitter.com/intent/follow?screen_name=hediet_dev)
 
-This unofficial extension integrates [Draw.io](https://app.diagrams.net/) (also known as [diagrams.net](diagrams.net)) into VS Code.
+This unofficial extension integrates [Draw.io](https://app.diagrams.net/) (also known as [diagrams.net](diagrams.net)) into VS Code.  
+Mentioned in the official diagrams.net [blog](https://www.diagrams.net/blog/embed-diagrams-vscode).
 
 ## Features
 


### PR DESCRIPTION
As a user searching the vs code extensions store I want to know if the vendor mentioned this extension and marks it as "we think this extension is cool".  
This gives me confidence to install this extension.