### PR TITLE
Update submodule "Draw.io" to fix Mathematical typesetting exporting issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.6-alpha.1] - 2022-09-28
+
+### Changed
+
+-   Updates Draw.io to 20.3.0
+
+### Fixed
+
+-   Maths not rendered when exporting diagram (address [#180](https://github.com/hediet/vscode-drawio/issues/180))
+
 ## [1.6.5] - 2022-03-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.6.6-alpha.1] - 2022-09-28
+## [1.6.6-alpha.1]
 
 ### Changed
 


### PR DESCRIPTION
Issue #180 
The version of Draw.io used in the project (v16.0.0) is causing this issue, so I updated submodule to v20.3.0.
However, I have not checked the effect on other features, so be careful about that.