### PR TITLE
Don't let draw.io handle cmd+p/cmd+shift+p on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.6] - ?
+
+### Added
+
+- Do not let draw.io handle cmd+p/cmd+shift+p keyboard shortcuts on Mac
+
 ## [1.6.5] - 2022-03-16
 
 ### Added

--- a/src/DrawioClient/webview-content.html
+++ b/src/DrawioClient/webview-content.html
@@ -334,11 +334,17 @@
 								if (keyEvt.key === "Tab" && keyEvt.ctrlKey) {
 									return;
 								}
-								if (keyEvt.key === "P" && (keyEvt.ctrlKey || keyEvt.metaKey)) {
+								if (
+									keyEvt.key === "P" &&
+									(keyEvt.ctrlKey || keyEvt.metaKey)
+								) {
 									// this covers ctrl+shift+p.
 									return;
 								}
-								if (keyEvt.key === "p" && (keyEvt.ctrlKey || keyEvt.metaKey)) {
+								if (
+									keyEvt.key === "p" &&
+									(keyEvt.ctrlKey || keyEvt.metaKey)
+								) {
 									// this covers ctrl+p.
 									// We don't need this keyboard shortcuts in drawio.
 									// Printing does not make sense in VS Code.

--- a/src/DrawioClient/webview-content.html
+++ b/src/DrawioClient/webview-content.html
@@ -334,11 +334,11 @@
 								if (keyEvt.key === "Tab" && keyEvt.ctrlKey) {
 									return;
 								}
-								if (keyEvt.key === "P" && keyEvt.ctrlKey) {
+								if (keyEvt.key === "P" && (keyEvt.ctrlKey || keyEvt.metaKey)) {
 									// this covers ctrl+shift+p.
 									return;
 								}
-								if (keyEvt.key === "p" && keyEvt.ctrlKey) {
+								if (keyEvt.key === "p" && (keyEvt.ctrlKey || keyEvt.metaKey)) {
 									// this covers ctrl+p.
 									// We don't need this keyboard shortcuts in drawio.
 									// Printing does not make sense in VS Code.


### PR DESCRIPTION
This is just matching the extension's behaviour on Windows already