### PR TITLE
Feature/simple labels config

### DIFF
--- a/examples/.vscode/settings.json
+++ b/examples/.vscode/settings.json
@@ -32,7 +32,7 @@
 				"fill": "#00ff00",
 				"stroke": "none",
 				"font": "#ffff00",
-				"gradient": "#0000ff",
+				"gradient": "#0000ff"
 			},
 			{
 				"fill": "#ffffba",
@@ -94,13 +94,10 @@
 			}
 		]
 	],
-	"hediet.vscode-drawio.presetColors": [
-		"ff0000",
-		"00ff00"
-	],
+	"hediet.vscode-drawio.presetColors": ["ff0000", "00ff00"],
 	"hediet.vscode-drawio.colorNames": {
 		"FF0000": "Red",
-		"00FF00": "Green",
+		"00FF00": "Green"
 	},
 	"hediet.vscode-drawio.simpleLabels": false,
 	"hediet.vscode-drawio.styles": [

--- a/examples/.vscode/settings.json
+++ b/examples/.vscode/settings.json
@@ -102,6 +102,7 @@
 		"FF0000": "Red",
 		"00FF00": "Green",
 	},
+	"hediet.vscode-drawio.simpleLabels": false,
 	"hediet.vscode-drawio.styles": [
 		{},
 		{

--- a/package.json
+++ b/package.json
@@ -232,6 +232,12 @@
 					"description": "Default styling of edges.",
 					"type": "object"
 				},
+				"hediet.vscode-drawio.simpleLabels": {
+					"type": "boolean",
+					"default": false,
+					"title": "Use SimpleLabels",
+					"description": "When enabled, no ForeignObjects are used in the svg."
+				},
 				"hediet.vscode-drawio.colorNames": {
 					"title": "Color Names",
 					"description": "Names for colors, eg. {‘FFFFFF’: ‘White’, ‘000000’: ‘Black’} that are used as tooltips (uppercase, no leading # for the colour codes)",

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -678,15 +678,15 @@ export class DiagramConfig {
 
 type DrawioCustomLibrary = (
 	| {
-		xml: string;
-	}
+			xml: string;
+	  }
 	| {
-		url: string;
-	}
+			url: string;
+	  }
 	| {
-		json: string;
-	}
+			json: string;
+	  }
 	| {
-		file: string;
-	}
+			file: string;
+	  }
 ) & { libName: string; entryId: string };

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -322,6 +322,23 @@ export class DiagramConfig {
 
 	//#endregion
 
+	//#region Simple Labels
+
+	private readonly _simpleLabels = new VsCodeSetting(
+		`${extensionId}.simpleLabels`,
+		{
+			scope: this.uri,
+			serializer: serializerWithDefault<boolean>(false),
+		}
+	);
+
+	@computed
+	public get simpleLabels(): boolean {
+		return this._simpleLabels.get();
+	}
+
+	//#endregion
+
 	//#region Preset Colors
 
 	private readonly _presetColors = new VsCodeSetting(
@@ -661,15 +678,15 @@ export class DiagramConfig {
 
 type DrawioCustomLibrary = (
 	| {
-			xml: string;
-	  }
+		xml: string;
+	}
 	| {
-			url: string;
-	  }
+		url: string;
+	}
 	| {
-			json: string;
-	  }
+		json: string;
+	}
 	| {
-			file: string;
-	  }
+		file: string;
+	}
 ) & { libName: string; entryId: string };

--- a/src/DrawioClient/DrawioClientFactory.ts
+++ b/src/DrawioClient/DrawioClientFactory.ts
@@ -233,6 +233,7 @@ export class DrawioClientFactory {
 			.replace(/\$\$literal-vsuri\$\$/g, vsuri.toString())
 			.replace("$$theme$$", JSON.stringify(config.theme))
 			.replace("$$lang$$", JSON.stringify(config.drawioLanguage))
+			.replace("$$simpleLabels$$", JSON.stringify(config.simpleLabels))
 			.replace(
 				"$$chrome$$",
 				JSON.stringify(options.isReadOnly ? "0" : "1")
@@ -278,7 +279,7 @@ export class DrawioClientFactory {
 
 				<iframe src="${drawioUrl}?embed=1&ui=${encodeURIComponent(
 			config.theme
-		)}&proto=json&configure=1&noSaveBtn=1&noExitBtn=1&lang=${encodeURIComponent(
+		)}&proto=json&configure=1&noSaveBtn=1&noExitBtn=1&simpleLabels=${encodeURIComponent(config.simpleLabels)}&lang=${encodeURIComponent(
 			config.drawioLanguage
 		)}"></iframe>
 			</body>

--- a/src/DrawioClient/DrawioClientFactory.ts
+++ b/src/DrawioClient/DrawioClientFactory.ts
@@ -20,7 +20,7 @@ export class DrawioClientFactory {
 		private readonly config: Config,
 		private readonly log: OutputChannel,
 		private readonly extensionUri: Uri
-	) {}
+	) { }
 
 	public async createDrawioClientInWebview(
 		uri: Uri,
@@ -54,6 +54,7 @@ export class DrawioClientFactory {
 				config.defaultVertexStyle;
 				config.defaultEdgeStyle;
 				config.colorNames;
+				config.simpleLabels;
 				config.zoomFactor;
 				config.globalVars;
 			},
@@ -86,6 +87,7 @@ export class DrawioClientFactory {
 					defaultVertexStyle: config.defaultVertexStyle,
 					defaultEdgeStyle: config.defaultEdgeStyle,
 					colorNames: config.colorNames,
+					simpleLabels: config.simpleLabels,
 					defaultLibraries: "general",
 					libraries: simpleDrawioLibrary(libs),
 					zoomFactor: config.zoomFactor,
@@ -296,6 +298,6 @@ function prettify(msg: unknown): string {
 			return formatValue(obj, process.env.DEV === "1" ? 500 : 80);
 		}
 		return formatValue(msg, process.env.DEV === "1" ? 500 : 80);
-	} catch {}
+	} catch { }
 	return "" + msg;
 }

--- a/src/DrawioClient/DrawioClientFactory.ts
+++ b/src/DrawioClient/DrawioClientFactory.ts
@@ -20,7 +20,7 @@ export class DrawioClientFactory {
 		private readonly config: Config,
 		private readonly log: OutputChannel,
 		private readonly extensionUri: Uri
-	) { }
+	) {}
 
 	public async createDrawioClientInWebview(
 		uri: Uri,
@@ -279,9 +279,9 @@ export class DrawioClientFactory {
 
 				<iframe src="${drawioUrl}?embed=1&ui=${encodeURIComponent(
 			config.theme
-		)}&proto=json&configure=1&noSaveBtn=1&noExitBtn=1&simpleLabels=${encodeURIComponent(config.simpleLabels)}&lang=${encodeURIComponent(
-			config.drawioLanguage
-		)}"></iframe>
+		)}&proto=json&configure=1&noSaveBtn=1&noExitBtn=1&simpleLabels=${encodeURIComponent(
+			config.simpleLabels
+		)}&lang=${encodeURIComponent(config.drawioLanguage)}"></iframe>
 			</body>
 		</html>
 			`;
@@ -299,6 +299,6 @@ function prettify(msg: unknown): string {
 			return formatValue(obj, process.env.DEV === "1" ? 500 : 80);
 		}
 		return formatValue(msg, process.env.DEV === "1" ? 500 : 80);
-	} catch { }
+	} catch {}
 	return "" + msg;
 }

--- a/src/DrawioClient/DrawioTypes.ts
+++ b/src/DrawioClient/DrawioTypes.ts
@@ -1,55 +1,55 @@
 export type DrawioEvent =
 	| {
-			event: "merge";
-			error: string;
-			message: DrawioEvent;
-	  }
+		event: "merge";
+		error: string;
+		message: DrawioEvent;
+	}
 	| {
-			event: "init";
-	  }
+		event: "init";
+	}
 	| {
-			event: "autosave";
-			xml: string;
-	  }
+		event: "autosave";
+		xml: string;
+	}
 	| {
-			event: "save";
-			xml: string;
-	  }
+		event: "save";
+		xml: string;
+	}
 	| {
-			event: "export";
-			data: string;
-			format: DrawioFormat;
-			xml: string;
-			message?: DrawioEvent;
-	  }
+		event: "export";
+		data: string;
+		format: DrawioFormat;
+		xml: string;
+		message?: DrawioEvent;
+	}
 	| {
-			event: "configure";
-	  };
+		event: "configure";
+	};
 
 export type DrawioAction =
 	| {
-			action: "load";
-			xml: string;
-			autosave?: 1;
-	  }
+		action: "load";
+		xml: string;
+		autosave?: 1;
+	}
 	| { action: "merge"; xml: string }
 	| {
-			action: "prompt";
-	  }
+		action: "prompt";
+	}
 	| {
-			action: "template";
-	  }
+		action: "template";
+	}
 	| {
-			action: "draft";
-	  }
+		action: "draft";
+	}
 	| {
-			action: "export";
-			format: DrawioFormat;
-	  }
+		action: "export";
+		format: DrawioFormat;
+	}
 	| {
-			action: "configure";
-			config: DrawioConfig;
-	  };
+		action: "configure";
+		config: DrawioConfig;
+	};
 // See https://desk.draw.io/support/solutions/articles/16000058316-how-to-configure-draw-io-
 
 export interface DrawioConfig {
@@ -118,6 +118,11 @@ export interface DrawioConfig {
 	 * Names for colors, eg. {‘FFFFFF’: ‘White’, ‘000000’: ‘Black’} that are used as tooltips (uppercase, no leading # for the colour codes).
 	 */
 	colorNames?: Record<string, string>;
+
+	/**
+	 * A boolean flag to allow usage of ForeignObjects in svg output (simpleLabels=false, default) or not.
+	 */
+	simpleLabels?: boolean;
 
 	/**
 	 * Defines a string with CSS rules to be used to configure the diagrams.net user interface.

--- a/src/DrawioClient/DrawioTypes.ts
+++ b/src/DrawioClient/DrawioTypes.ts
@@ -1,55 +1,55 @@
 export type DrawioEvent =
 	| {
-		event: "merge";
-		error: string;
-		message: DrawioEvent;
-	}
+			event: "merge";
+			error: string;
+			message: DrawioEvent;
+	  }
 	| {
-		event: "init";
-	}
+			event: "init";
+	  }
 	| {
-		event: "autosave";
-		xml: string;
-	}
+			event: "autosave";
+			xml: string;
+	  }
 	| {
-		event: "save";
-		xml: string;
-	}
+			event: "save";
+			xml: string;
+	  }
 	| {
-		event: "export";
-		data: string;
-		format: DrawioFormat;
-		xml: string;
-		message?: DrawioEvent;
-	}
+			event: "export";
+			data: string;
+			format: DrawioFormat;
+			xml: string;
+			message?: DrawioEvent;
+	  }
 	| {
-		event: "configure";
-	};
+			event: "configure";
+	  };
 
 export type DrawioAction =
 	| {
-		action: "load";
-		xml: string;
-		autosave?: 1;
-	}
+			action: "load";
+			xml: string;
+			autosave?: 1;
+	  }
 	| { action: "merge"; xml: string }
 	| {
-		action: "prompt";
-	}
+			action: "prompt";
+	  }
 	| {
-		action: "template";
-	}
+			action: "template";
+	  }
 	| {
-		action: "draft";
-	}
+			action: "draft";
+	  }
 	| {
-		action: "export";
-		format: DrawioFormat;
-	}
+			action: "export";
+			format: DrawioFormat;
+	  }
 	| {
-		action: "configure";
-		config: DrawioConfig;
-	};
+			action: "configure";
+			config: DrawioConfig;
+	  };
 // See https://desk.draw.io/support/solutions/articles/16000058316-how-to-configure-draw-io-
 
 export interface DrawioConfig {


### PR DESCRIPTION
Change to add the simpleLabels config option as described in https://github.com/hediet/vscode-drawio/issues/353. 
In general, looking at https://www.diagrams.net/doc/faq/configure-diagram-editor there are quite a few config options that are not currently configurable. Perhaps it might make sense to have a generic json config for all of these, although I understand most users probably do not have the necessity to adjust these. 

Tested locally with the VSCode debugger but only in online mode. Offline mode would not load but I was not able to debug the reason (it was the same in master or v1.6.4). 

Note there are some auto-linting changes. 