### PR TITLE
Fix link to diagrams.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![](https://img.shields.io/static/v1?style=social&label=Donate&message=%E2%9D%A4&logo=Paypal&color&link=%3Curl%3E)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=ZP5F38L4C88UY&source=url)
 [![](https://img.shields.io/twitter/follow/hediet_dev.svg?style=social)](https://twitter.com/intent/follow?screen_name=hediet_dev)
 
-This unofficial extension integrates [Draw.io](https://app.diagrams.net/) (also known as [diagrams.net](diagrams.net)) into VS Code.  
+This unofficial extension integrates [Draw.io](https://app.diagrams.net/) (also known as [diagrams.net](https://www.diagrams.net/)) into VS Code.  
 Mentioned in the official diagrams.net [blog](https://www.diagrams.net/blog/embed-diagrams-vscode).
 
 ## Features


### PR DESCRIPTION
Currently the second link in the Readme is interpreted as a relative path so it leads to a 404 page:
> This unofficial extension integrates [Draw.io](https://app.diagrams.net/) (also known as [diagrams.net](https://github.com/hediet/vscode-drawio/blob/master/diagrams.net)) into VS Code.

![grafik](https://user-images.githubusercontent.com/11715448/232319850-965074a5-f943-4646-8034-c4be7a99d4c6.png)