### PR TITLE
Fix the font display problem in some dialog

### DIFF
--- a/src/DrawioClient/webview-content.html
+++ b/src/DrawioClient/webview-content.html
@@ -173,10 +173,6 @@
 		<link rel="stylesheet" type="text/css" href="styles/grapheditor.css" />
 		<link rel="manifest" href="images/manifest.json" />
 		<style type="text/css">
-			.geEditor {
-				color: black;
-				background-color: white;
-			}
 			body {
 				overflow: hidden;
 			}


### PR DESCRIPTION
issue：#382 
It seems that drawio already supports dark/light mode, so this css style seems to be no longer needed. 
it will affect the font display in drak mode.

before：
![pic2](https://github.com/hediet/vscode-drawio/assets/60056665/adfd4c9f-e48b-4c30-a88b-0d7a3573705c)
![pic1](https://github.com/hediet/vscode-drawio/assets/60056665/369174a0-02b4-41e9-a106-9d0b91409e79)

after：
![pic3](https://github.com/hediet/vscode-drawio/assets/60056665/1c2941a0-30e8-4d6c-adb4-7fd453e2663b)
![pic4](https://github.com/hediet/vscode-drawio/assets/60056665/189dc1f3-3656-4ad4-83b7-f8edf39f291a)


