### PR TITLE
Using default editor in diff mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -429,8 +429,7 @@
 		},
 		"configurationDefaults": {
     			"workbench.editorAssociations": {
-      				"git:/**/*.{drawio,dio,dio.svg,drawio.svg}": "default",
-      				"gitlens:/**/*.{drawio,dio,dio.svg,drawio.svg}": "default"
+      				"{git,gitlens}:/**/*.{drawio,dio,dio.svg,drawio.svg}": "default"
     			}
   		},
 		"menus": {

--- a/package.json
+++ b/package.json
@@ -427,6 +427,12 @@
 				}
 			}
 		},
+		"configurationDefaults": {
+    			"workbench.editorAssociations": {
+      				"git:/**/*.{drawio,dio,dio.svg,drawio.svg}": "default",
+      				"gitlens:/**/*.{drawio,dio,dio.svg,drawio.svg}": "default"
+    			}
+  		},
 		"menus": {
 			"explorer/context": [
 				{

--- a/package.json
+++ b/package.json
@@ -428,10 +428,10 @@
 			}
 		},
 		"configurationDefaults": {
-    			"workbench.editorAssociations": {
-      				"{git,gitlens}:/**/*.{drawio,dio,dio.svg,drawio.svg}": "default"
-    			}
-  		},
+			"workbench.editorAssociations": {
+				"{git,gitlens}:/**/*.{drawio,dio,dio.svg,drawio.svg}": "default"
+			}
+		},
 		"menus": {
 			"explorer/context": [
 				{


### PR DESCRIPTION
Fix: https://github.com/hediet/vscode-drawio/issues/27

`configurationDefaults` with `workbench.editorAssociations` should work fine use in `VS Code 1.86.0`. See:  https://github.com/microsoft/vscode/issues/138525#issuecomment-1847679100