### PR TITLE
Add gitlens readonly scheme

### DIFF
--- a/src/DrawioEditorProviderText.ts
+++ b/src/DrawioEditorProviderText.ts
@@ -20,7 +20,11 @@ export class DrawioEditorProviderText implements CustomTextEditorProvider {
 		token: CancellationToken
 	): Promise<void> {
 		try {
-			const readonlySchemes = new Set(["git", "conflictResolution"]);
+			const readonlySchemes = new Set([
+				"git",
+				"conflictResolution",
+				"gitlens",
+			]);
 			const isReadOnly = readonlySchemes.has(document.uri.scheme);
 
 			const editor =


### PR DESCRIPTION
Fix open diff in gitlens will use edit mode.

<img width="1437" alt="Screen Shot 2023-12-16 at 10 55 26" src="https://github.com/hediet/vscode-drawio/assets/25266120/132ae7a2-93d1-4162-b777-fc9950f747cd">
