### PR TITLE
Add enableLightDarkColors configuration

### DIFF
--- a/examples/.vscode/settings.json
+++ b/examples/.vscode/settings.json
@@ -100,6 +100,7 @@
 		"00FF00": "Green"
 	},
 	"hediet.vscode-drawio.simpleLabels": false,
+	"hediet.vscode-drawio.enableLightDarkColors": true,
 	"hediet.vscode-drawio.styles": [
 		{},
 		{

--- a/package.json
+++ b/package.json
@@ -203,6 +203,13 @@
 						"description": "When enabled, no ForeignObjects are used in the svg.",
 						"order": 40
 					},
+					"hediet.vscode-drawio.enableLightDarkColors": {
+						"type": "boolean",
+						"default": true,
+						"title": "Enable light-dark Colors",
+						"description": "Specifies if the light-dark color function should be used for colors.",
+						"order": 45
+					},
 					"hediet.vscode-drawio.zoomFactor": {
 						"type": "number",
 						"default": 1.2,

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -338,6 +338,23 @@ export class DiagramConfig {
 
 	//#endregion
 
+	//#region Enable Light Dark Colors
+
+	private readonly _enableLightDarkColors = new VsCodeSetting(
+		`${extensionId}.enableLightDarkColors`,
+		{
+			scope: this.uri,
+			serializer: serializerWithDefault<boolean>(true),
+		}
+	);
+
+	@computed
+	public get enableLightDarkColors(): boolean {
+		return this._enableLightDarkColors.get();
+	}
+
+	//#endregion
+
 	//#region Preset Colors
 
 	private readonly _presetColors = new VsCodeSetting(

--- a/src/DrawioClient/DrawioClientFactory.ts
+++ b/src/DrawioClient/DrawioClientFactory.ts
@@ -50,6 +50,7 @@ export class DrawioClientFactory {
 				config.defaultEdgeStyle;
 				config.colorNames;
 				config.simpleLabels;
+				config.enableLightDarkColors;
 				config.zoomFactor;
 				config.globalVars;
 				config.resizeImages;
@@ -93,6 +94,7 @@ export class DrawioClientFactory {
 					defaultEdgeStyle: config.defaultEdgeStyle,
 					colorNames: config.colorNames,
 					simpleLabels: config.simpleLabels,
+					enableLightDarkColors: config.enableLightDarkColors,
 					defaultLibraries: "general",
 					libraries: simpleDrawioLibrary(libs),
 					zoomFactor: config.zoomFactor,
@@ -241,6 +243,10 @@ export class DrawioClientFactory {
 			.replace("$$lang$$", JSON.stringify(config.drawioLanguage))
 			.replace("$$simpleLabels$$", JSON.stringify(config.simpleLabels))
 			.replace(
+				"$$enableLightDarkColors$$",
+				JSON.stringify(config.enableLightDarkColors)
+			)
+			.replace(
 				"$$chrome$$",
 				JSON.stringify(options.isReadOnly ? "0" : "1")
 			)
@@ -287,6 +293,8 @@ export class DrawioClientFactory {
 			config.resolvedTheme.themeName
 		)}&proto=json&configure=1&noSaveBtn=1&noExitBtn=1&simpleLabels=${encodeURIComponent(
 			config.simpleLabels
+		)}&enableLightDarkColors=${encodeURIComponent(
+			config.enableLightDarkColors
 		)}&lang=${encodeURIComponent(config.drawioLanguage)}"></iframe>
 			</body>
 		</html>

--- a/src/DrawioClient/DrawioTypes.ts
+++ b/src/DrawioClient/DrawioTypes.ts
@@ -125,6 +125,11 @@ export interface DrawioConfig {
 	simpleLabels?: boolean;
 
 	/**
+	 * Specifies if the `light-dark` color function should be used for colors. The default is true.
+	 */
+	enableLightDarkColors?: boolean;
+
+	/**
 	 * Defines a string with CSS rules to be used to configure the diagrams.net user interface.
 	 * For example, to change the background colour of the menu bar, use the following:
 	 * ```css

--- a/src/DrawioClient/webview-content.html
+++ b/src/DrawioClient/webview-content.html
@@ -126,6 +126,7 @@
 				lang: $$lang$$,
 				noSaveBtn: "1",
 				noExitBtn: "1",
+				enableLightDarkColors: $$enableLightDarkColors$$,
 				chrome: $$chrome$$,
 				get ["svg-warning"]() {
 					return editorUi.fileNode.getAttribute(


### PR DESCRIPTION
Update draw.io to v26.0.13, which adds the enableLightDarkColors config.

When true (default), the light-dark function renders different colors based on the theme.
This is the current default of draw.io.

When false, draw.io reverts to the previous single-color mode.