### PR TITLE
Select the current page when exporting svg/png

### DIFF
--- a/src/DrawioClient/DrawioClient.ts
+++ b/src/DrawioClient/DrawioClient.ts
@@ -238,6 +238,7 @@ export class DrawioClient<
 		const response = await this.sendActionWaitForResponse({
 			action: "export",
 			format: "xmlpng",
+			currentPage: true,
 		});
 		if (response.event !== "export") {
 			throw new Error("Unexpected response");
@@ -254,6 +255,7 @@ export class DrawioClient<
 		const response = await this.sendActionWaitForResponse({
 			action: "export",
 			format: "xmlsvg",
+			currentPage: true,
 		});
 		if (response.event !== "export") {
 			throw new Error("Unexpected response");

--- a/src/DrawioClient/DrawioTypes.ts
+++ b/src/DrawioClient/DrawioTypes.ts
@@ -45,6 +45,7 @@ export type DrawioAction =
 	| {
 			action: "export";
 			format: DrawioFormat;
+			currentPage?: boolean;
 	  }
 	| {
 			action: "configure";


### PR DESCRIPTION
Fixes #108. Tested and worked fine.

Ref: https://www.drawio.com/doc/faq/embed-mode

> An optional pageId parameter can be used to specify the page to be exported, or else **currentPage (boolean) can be used to specify to export the current selected page**.