### PR TITLE
fix: restrict customLibraries file paths to workspace folder

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,4 +1,5 @@
 import { autorun, computed, observable } from "mobx";
+import * as path from "path";
 import {
 	ColorTheme,
 	ColorThemeKind,
@@ -587,7 +588,17 @@ export class DiagramConfig {
 					lib.file,
 					"custom libraries"
 				);
-				const buffer = await workspace.fs.readFile(Uri.file(file));
+				const resolvedFile = path.resolve(file);
+				const workspaceFolder = workspace.getWorkspaceFolder(this.uri);
+				if (workspaceFolder) {
+					const wsRoot = workspaceFolder.uri.fsPath;
+					if (!resolvedFile.startsWith(wsRoot + path.sep) && resolvedFile !== wsRoot) {
+						throw new Error(
+							`Custom library file "${lib.file}" resolves to "${resolvedFile}" which is outside the workspace folder. For security, library files must be within the workspace.`
+						);
+					}
+				}
+				const buffer = await workspace.fs.readFile(Uri.file(resolvedFile));
 				const content = BufferImpl.from(buffer).toString("utf-8");
 				if (file.endsWith(".json")) {
 					data = {

--- a/test-path-containment.js
+++ b/test-path-containment.js
@@ -1,0 +1,55 @@
+/**
+ * Standalone test for the path containment fix in customLibraries.
+ *
+ * Run with: node test-path-containment.js
+ *
+ * This project has no test runner, so this file validates the path
+ * containment logic directly using Node's assert module.
+ */
+const path = require("path");
+const assert = require("assert");
+
+/**
+ * Replicates the path containment check added to Config.ts.
+ * Returns true if the resolved path is within wsRoot, false otherwise.
+ */
+function isWithinWorkspace(filePath, wsRoot) {
+  const resolved = path.resolve(filePath);
+  return resolved.startsWith(wsRoot + path.sep) || resolved === wsRoot;
+}
+
+const wsRoot = "/home/user/project";
+
+// Test 1: Normal path within workspace (should pass)
+const normalPath = path.join(wsRoot, "libs", "my-library.json");
+assert.strictEqual(isWithinWorkspace(normalPath, wsRoot), true,
+  "Normal path within workspace should be allowed");
+console.log("PASS: Normal path within workspace");
+
+// Test 2: Template-expanded path within workspace (should pass)
+const templatePath = wsRoot + "/libs/shapes.xml";
+assert.strictEqual(isWithinWorkspace(templatePath, wsRoot), true,
+  "Template-expanded workspace path should be allowed");
+console.log("PASS: Template-expanded path");
+
+// Test 3: Absolute path outside workspace (should be blocked)
+assert.strictEqual(isWithinWorkspace("/etc/passwd", wsRoot), false,
+  "Absolute path outside workspace must be blocked");
+console.log("PASS: Absolute path /etc/passwd blocked");
+
+// Test 4: Relative traversal via ../ (should be blocked)
+assert.strictEqual(isWithinWorkspace(wsRoot + "/../../../etc/shadow", wsRoot), false,
+  "Relative traversal via ../ must be blocked");
+console.log("PASS: Relative traversal ../../etc/shadow blocked");
+
+// Test 5: Sibling directory with same prefix (should be blocked)
+assert.strictEqual(isWithinWorkspace(wsRoot + "-secret/data.json", wsRoot), false,
+  "Sibling directory with same prefix must be blocked");
+console.log("PASS: Sibling dir with same prefix blocked");
+
+// Test 6: Workspace root itself (edge case, should pass)
+assert.strictEqual(isWithinWorkspace(wsRoot, wsRoot), true,
+  "Workspace root itself should be allowed");
+console.log("PASS: Workspace root itself allowed");
+
+console.log("\nAll 6 tests passed.");


### PR DESCRIPTION
## Security Fix: Path Traversal via customLibraries Setting

### Vulnerable Lines

**File:** [`src/Config.ts#L586-L590`](https://github.com/hediet/vscode-drawio/blob/master/src/Config.ts#L586-L590)

```typescript
} else if ("file" in lib) {
    const file = this.evaluateTemplate(lib.file, "custom libraries");
    const buffer = await workspace.fs.readFile(Uri.file(file));
    // ^^^ No check that `file` is within the workspace folder
```

`evaluateTemplate()` only substitutes `${workspaceFolder}` - it performs no path containment. Any absolute path or `../` traversal is passed directly to `workspace.fs.readFile()`. Since the extension declares `untrustedWorkspaces.supported: true`, VS Code does not warn the user when opening a workspace with these settings.

### What could happen

An attacker creates a repository with a `.vscode/settings.json` like:

```json
{
  "hediet.vscode-drawio.customLibraries": [
    { "libName": "x", "entryId": "x", "file": "/etc/passwd" }
  ]
}
```

When a victim clones the repo and opens any `.drawio` file, the extension reads the targeted file. Since the extension runs in the VS Code extension host process, it can read anything the user's VS Code process can: SSH keys, cloud credentials, environment files, etc.

### How to verify

1. Create a temporary workspace with the malicious `settings.json` shown above and a minimal `.drawio` file
2. Open the workspace in VS Code with vscode-drawio installed
3. Open the `.drawio` file
4. Observe that the extension attempts to read `/etc/passwd` (an error will appear because the content isn't valid library JSON, but the file *is* read)

Full reproduction traces: [evidence gist](https://gist.github.com/theeggorchicken/4dd7ec89caddf31ae8b5ee47ce040e76)

End-to-end validation was performed using `@vscode/test-electron` with VS Code 1.109.5 and vscode-drawio v1.9.0. A canary file placed outside the workspace was read by the extension after opening a `.drawio` file, confirmed by `atime` change on the canary (before: `1771710897384`, after: `1771714497557`).

### What this PR does

After `evaluateTemplate()` resolves the file path, the resolved path is normalized via `path.resolve()` and checked against the workspace folder root. If the path does not start with the workspace folder (plus a path separator, to avoid prefix collisions with sibling directories), an error is thrown with a clear message.

This is consistent with how VS Code's own workspace trust model works: workspace settings should not be able to escape the workspace boundary.

### Tests included

- `test-path-containment.js` - six cases:
  - Normal path within workspace is allowed
  - Template-expanded workspace path is allowed
  - Absolute path outside workspace (`/etc/passwd`) is blocked
  - Relative traversal (`../../etc/shadow`) is blocked
  - Sibling directory with same prefix (`project-secret/`) is blocked
  - Workspace root itself is allowed (edge case)

Note: this project has no test runner infrastructure, so the test is a standalone Node.js script (`node test-path-containment.js`).

### Evidence

- [Reproduction traces and end-to-end validation output](https://gist.github.com/theeggorchicken/4dd7ec89caddf31ae8b5ee47ce040e76)