### PR TITLE
fix: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/opened-issues-triage.yml
+++ b/.github/workflows/opened-issues-triage.yml
@@ -8,7 +8,7 @@ jobs:
   automate-project-columns:
     runs-on: ubuntu-latest
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.2.3
+      - uses: alex-page/github-project-automation-plus@0a4f775fa2e62ac007a561cd051628689dbce33d # v0.2.3
         with:
           project: Backlog
           column: Triage


### PR DESCRIPTION
Re-submission of #496. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags and extracts any unsafe expressions from run blocks into env mappings.

## How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3`, original version preserved as comment
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)
