### PR TITLE
Expand globalVars with path information

### DIFF
--- a/examples/.vscode/settings.json
+++ b/examples/.vscode/settings.json
@@ -130,5 +130,9 @@
 				"gridColor": "#0B3240"
 			}
 		}
-	]
+	],
+	"hediet.vscode-drawio.globalVars": {
+		"workspaceFolder": "${workspaceFolder}",
+		"filePath": "${filePath}",
+	}
 }

--- a/src/DrawioClient/DrawioClientFactory.ts
+++ b/src/DrawioClient/DrawioClientFactory.ts
@@ -14,6 +14,8 @@ import { autorun, observable, runInAction, untracked } from "mobx";
 import { sha256 } from "js-sha256";
 import { getDrawioExtensions } from "../DrawioExtensionApi";
 import { BufferImpl } from "../utils/buffer";
+import { SimpleTemplate } from "../utils/SimpleTemplate";
+import { mapObject } from "../utils/mapObject";
 
 export class DrawioClientFactory {
 	constructor(
@@ -96,7 +98,7 @@ export class DrawioClientFactory {
 					defaultLibraries: "general",
 					libraries: simpleDrawioLibrary(libs),
 					zoomFactor: config.zoomFactor,
-					globalVars: config.globalVars,
+					globalVars: this.expandGlobalVars(config.globalVars, uri),
 				};
 			},
 			() => {
@@ -198,6 +200,27 @@ export class DrawioClientFactory {
 
 		await Promise.all(promises);
 		return pluginsToLoad;
+	}
+
+	private expandGlobalVars(globalVars: object | null, uri: Uri): object | null {
+		if (!globalVars) { return globalVars; }
+
+		const workspaceFolder = workspace.getWorkspaceFolder(uri)?.uri.fsPath;
+		const filePath = workspace.asRelativePath(uri)
+		if (!workspaceFolder || !filePath) {
+			console.warn(`Cannot get workspace information to expand globalVars`)
+			return globalVars
+		}
+
+		const expandedVars = mapObject(globalVars, (value: string) => {
+			const tpl = new SimpleTemplate(value);
+			return tpl.render({
+				filePath: () => filePath,
+				workspaceFolder: () => workspaceFolder
+			})
+		})
+
+		return expandedVars
 	}
 
 	private getHtml(


### PR DESCRIPTION
In order for drawio plugins to be of use inside VSCode you might need to circle back some original file information. The easiest way to enable this is to leverage the existing `globalVars` object and expand variables with path information from the file and the workspace.

Specifically it replaces '${workspaceFolder}' and '${filePath}' with actual path information.

In the `examples/.vscodee/settings.json` an example is shown.

The functionality can be validated by:
- launching the extension from within VSCode,
- firing up the developer tools
- open an example DrawIO image
- select the frame that contains the DrawIO instance
- Inspecting `Editor.globalVars` on the console