### PR TITLE
Quality: Destructuring `this.api.exports` without null check crashes when extension activation returns void

### DIFF
--- a/src/DrawioExtensionApi.ts
+++ b/src/DrawioExtensionApi.ts
@@ -13,23 +13,27 @@ export function getDrawioExtensions(): DrawioExtension[] {
 export class DrawioExtension {
 	constructor(private readonly api: Extension<DrawioExtensionApi>) {}
 
-	public async getDrawioPlugins(
-		context: DocumentContext
-	): Promise<{ jsCode: string }[]> {
-		if (!this.api.isActive) {
-			await this.api.activate();
-		}
-		const { drawioExtensionV1 } = this.api.exports;
-		if (drawioExtensionV1) {
-			const { getDrawioPlugins } = drawioExtensionV1;
-			if (getDrawioPlugins) {
-				return await getDrawioPlugins.apply(drawioExtensionV1, [
-					context,
-				]);
+		public async getDrawioPlugins(
+			context: DocumentContext
+		): Promise<{ jsCode: string }[]> {
+			if (!this.api.isActive) {
+				await this.api.activate();
 			}
+			const exports = this.api.exports;
+			if (!exports) {
+				return [];
+			}
+			const { drawioExtensionV1 } = exports;
+			if (drawioExtensionV1) {
+				const { getDrawioPlugins } = drawioExtensionV1;
+				if (getDrawioPlugins) {
+					return await getDrawioPlugins.apply(drawioExtensionV1, [
+						context,
+					]);
+				}
+			}
+			return [];
 		}
-		return [];
-	}
 }
 
 export interface DrawioExtensionJsonManifest {


### PR DESCRIPTION
## Problem

After `await this.api.activate()`, the code immediately destructures `this.api.exports`: `const { drawioExtensionV1 } = this.api.exports;` In the VS Code extension API, if an extension's `activate()` function returns `void` or `undefined` (which is the most common pattern), `extension.exports` is `undefined`. Destructuring `undefined` throws `TypeError: Cannot destructure property 'drawioExtensionV1' of undefined`. This crashes whenever a third-party extension declares `"isDrawioExtension": true` in its package.json but doesn't return an API object from its activate function — a very common scenario since many extensions use `export function activate() { ... }` without a return value.


**Severity**: `high`
**File**: `src/DrawioExtensionApi.ts`

## Solution

public async getDrawioPlugins(
    context: DocumentContext
): Promise<{ jsCode: string }[]> {
    if (!this.api.isActive) {
        await this.api.activate();
    }
    const exports = this.api.exports;
    if (!exports) {
        return [];
    }
    const { drawioExtensionV1 } = exports;
    if (drawioExtensionV1) {
        const { getDrawioPlugins } = drawioExtensionV1;
        if (getDrawioPlugins) {
            return await getDrawioPlugins.apply(drawioExtensionV1, [
                context,
            ]);
        }
    }
    return [];
}


## Changes

- `src/DrawioExtensionApi.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
