### PR TITLE
Docs: Public extension API (DrawioExtensionApi) lacks documentation

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -22,6 +22,11 @@ import * as packageJson from "../package.json";
 const extensionId = "hediet.vscode-drawio";
 const experimentalFeaturesEnabled = "vscode-drawio.experimentalFeaturesEnabled";
 
+/**
+ * Sets a VS Code context value that can be used in when clauses.
+ * @param key - The context key to set.
+ * @param value - The value to set for the context key.
+ */
 export async function setContext(
 	key: string,
 	value: string | boolean
@@ -29,6 +34,10 @@ export async function setContext(
 	return (await commands.executeCommand("setContext", key, value)) as any;
 }
 
+/**
+ * Manages configuration and settings for the draw.io extension.
+ * Handles experimental features, plugin management, theme detection, and feedback mechanisms.
+ */
 export class Config {
 	public readonly packageJson: {
 		version: string;

--- a/src/DrawioExtensionApi.ts
+++ b/src/DrawioExtensionApi.ts
@@ -1,5 +1,10 @@
 import { Extension, extensions, Uri } from "vscode";
 
+/**
+ * Returns all extensions that have been registered as draw.io extensions.
+ * These extensions must set `"isDrawioExtension": true` in their package.json.
+ * @returns Array of DrawioExtension instances for each registered draw.io extension.
+ */
 export function getDrawioExtensions(): DrawioExtension[] {
 	return extensions.all
 		.filter(
@@ -10,9 +15,19 @@ export function getDrawioExtensions(): DrawioExtension[] {
 		.map((e) => new DrawioExtension(e));
 }
 
+/**
+ * Represents a draw.io extension that can provide plugins for the draw.io editor.
+ * Extension developers should implement the DrawioExtensionApi interface and register their extension
+ * by setting `"isDrawioExtension": true` in their package.json.
+ */
 export class DrawioExtension {
 	constructor(private readonly api: Extension<DrawioExtensionApi>) {}
 
+	/**
+	 * Retrieves draw.io plugins provided by this extension.
+	 * @param context - The document context for which plugins are requested.
+	 * @returns A promise that resolves to an array of plugin objects, each containing jsCode to be executed in the draw.io editor.
+	 */
 	public async getDrawioPlugins(
 		context: DocumentContext
 	): Promise<{ jsCode: string }[]> {
@@ -32,21 +47,63 @@ export class DrawioExtension {
 	}
 }
 
+/**
+ * Manifest interface for draw.io extensions.
+ * Extensions must include this structure in their package.json to be recognized as draw.io extensions.
+ * @example
+ * // In your extension's package.json:
+ * {
+ *   "name": "my-drawio-plugin",
+ *   "isDrawioExtension": true,
+ *   "main": "./out/extension.js"
+ * }
+ */
 export interface DrawioExtensionJsonManifest {
-	// Set `"isDrawioExtension": true` in your package.json
-	// so that your extension gets loaded when a draw.io file is opened.
+	/**
+	 * Set to `true` in your package.json so that your extension gets loaded when a draw.io file is opened.
+	 */
 	isDrawioExtension?: boolean;
 }
 
-// Implement this API in your public extension API.
+/**
+ * Public API interface that draw.io extensions must implement.
+ * Your extension should export an object conforming to this interface as its main export.
+ * The draw.io extension will call the `getDrawioPlugins` method to retrieve custom plugins.
+ * @example
+ * // In your extension.ts:
+ * export function activate(context: vscode.ExtensionContext) {
+ *   return {
+ *     drawioExtensionV1: {
+ *       getDrawioPlugins: async (context) => {
+ *         return [{ jsCode: 'console.log("Hello from my plugin!")' }];
+ *       }
+ *     }
+ *   };
+ * }
+ */
 export interface DrawioExtensionApi {
+	/**
+	 * Version 1 of the draw.io extension API.
+	 */
 	drawioExtensionV1?: {
+		/**
+		 * Returns draw.io plugins for the given document context.
+		 * @param context - The document context (currently only contains the URI of the document).
+		 * @returns A promise that resolves to an array of plugin objects.
+		 */
 		getDrawioPlugins?: (
 			context: DocumentContext
 		) => Promise<{ jsCode: string }[]>;
 	};
 }
 
+/**
+ * Context information about the document for which plugins are requested.
+ * Currently only contains the URI of the document being edited.
+ */
 export interface DocumentContext {
+	/**
+	 * The URI of the document being edited in the draw.io editor.
+	 */
 	uri: Uri;
 }


### PR DESCRIPTION
## Problem

The file defines a public API for other extensions to integrate with draw.io (DrawioExtension, DrawioExtensionApi, DocumentContext, etc.) but has no documentation. Extension developers cannot understand how to use this API without reading source code.

**Severity**: `high`
**File**: `src/DrawioExtensionApi.ts`

## Solution

Add a README section or detailed docstrings explaining: 1) How to set up a draw.io extension plugin 2) The DrawioExtensionApi interface requirements 3) The DrawioExtensionJsonManifest manifest structure 4) Example usage with code samples.

## Changes

- `src/DrawioExtensionApi.ts` (modified)
- `src/Config.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
