### PR TITLE
Add scale option to PNG export (fixes #426)

### DIFF
--- a/src/DrawioClient/DrawioClient.ts
+++ b/src/DrawioClient/DrawioClient.ts
@@ -208,9 +208,12 @@ export class DrawioClient<
 		this.loadXmlLike("data:image/png;base64," + str);
 	}
 
-	public async export(extension: string): Promise<BufferImpl> {
+	public async export(
+		extension: string,
+		scale?: number
+	): Promise<BufferImpl> {
 		if (extension.endsWith(".png")) {
-			return await this.exportAsPngWithEmbeddedXml();
+			return await this.exportAsPngWithEmbeddedXml(scale);
 		} else if (
 			extension.endsWith(".drawio") ||
 			extension.endsWith(".dio")
@@ -249,10 +252,13 @@ export class DrawioClient<
 		return this.currentXml;
 	}
 
-	public async exportAsPngWithEmbeddedXml(): Promise<BufferImpl> {
+	public async exportAsPngWithEmbeddedXml(
+		scale?: number
+	): Promise<BufferImpl> {
 		const response = await this.sendActionWaitForResponse({
 			action: "export",
 			format: "xmlpng",
+			...(scale !== undefined ? { scale } : {}),
 		});
 		if (response.event !== "export") {
 			throw new Error("Unexpected response");

--- a/src/DrawioClient/DrawioTypes.ts
+++ b/src/DrawioClient/DrawioTypes.ts
@@ -45,6 +45,7 @@ export type DrawioAction =
 	| {
 			action: "export";
 			format: DrawioFormat;
+			scale?: number;
 	  }
 	| {
 			action: "configure";

--- a/src/DrawioEditorService.ts
+++ b/src/DrawioEditorService.ts
@@ -20,6 +20,7 @@ import {
 	DrawioClientOptions,
 } from "./DrawioClient";
 import { DrawioBinaryDocument } from "./DrawioEditorProviderBinary";
+import { parseScale } from "./utils/parseScale";
 import { registerFailableCommand } from "./utils/registerFailableCommand";
 
 const drawioChangeThemeCommand = "hediet.vscode-drawio.changeTheme";
@@ -342,14 +343,14 @@ export class DrawioEditor {
 				prompt: "Zoom level for the PNG export (e.g. 1, 2, 3)",
 				value: "1",
 				validateInput: (value) =>
-					Number(value) > 0
-						? undefined
-						: "Enter a number greater than 0",
+					parseScale(value) === undefined
+						? "Enter a number greater than 0"
+						: undefined,
 			});
 			if (scaleInput === undefined) {
 				return;
 			}
-			scale = Number(scaleInput);
+			scale = parseScale(scaleInput);
 		}
 
 		await this.exportTo(result.label, scale);

--- a/src/DrawioEditorService.ts
+++ b/src/DrawioEditorService.ts
@@ -4,12 +4,14 @@ import { autorun, computed, observable, ObservableSet } from "mobx";
 import { extname } from "path";
 import {
 	commands,
-	QuickPickItem, QuickPickItemKind, StatusBarAlignment,
+	QuickPickItem,
+	QuickPickItemKind,
+	StatusBarAlignment,
 	TextDocument,
 	Uri,
 	WebviewPanel,
 	window,
-	workspace
+	workspace,
 } from "vscode";
 import { Config, DiagramConfig, ResolvedDrawioTheme } from "./Config";
 import {
@@ -274,8 +276,11 @@ export class DrawioEditor {
 		}
 	}
 
-	public async exportTo(targetExtension: string): Promise<void> {
-		const buffer = await this.drawioClient.export(targetExtension);
+	public async exportTo(
+		targetExtension: string,
+		scale?: number
+	): Promise<void> {
+		const buffer = await this.drawioClient.export(targetExtension, scale);
 		const targetUri = await window.showSaveDialog({
 			defaultUri: this.getUriWithExtension(targetExtension),
 		});
@@ -330,21 +335,49 @@ export class DrawioEditor {
 		if (!result) {
 			return;
 		}
-		await this.exportTo(result.label);
+
+		let scale: number | undefined;
+		if (result.label === ".png") {
+			const scaleInput = await window.showInputBox({
+				prompt: "Zoom level for the PNG export (e.g. 1, 2, 3)",
+				value: "1",
+				validateInput: (value) =>
+					Number(value) > 0
+						? undefined
+						: "Enter a number greater than 0",
+			});
+			if (scaleInput === undefined) {
+				return;
+			}
+			scale = Number(scaleInput);
+		}
+
+		await this.exportTo(result.label, scale);
 	}
 
 	public async handleChangeThemeCommand(): Promise<void> {
 		const originalTheme = this.config.theme;
 		const originalAppearance = this.config.appearance;
-		const availableThemes = withFirstUnique(ResolvedDrawioTheme.getThemeNames(), originalTheme);
+		const availableThemes = withFirstUnique(
+			ResolvedDrawioTheme.getThemeNames(),
+			originalTheme
+		);
 
-		const availableOptions: (QuickPickItem & { onSelect?: (preview: boolean) => void })[] = [];
+		const availableOptions: (QuickPickItem & {
+			onSelect?: (preview: boolean) => void;
+		})[] = [];
 
 		const curVsCodeAppearance = this.config.getVsCodeAppearance();
 
-		const appearances = withFirstUnique(["automatic", "light", "dark"], originalAppearance);
+		const appearances = withFirstUnique(
+			["automatic", "light", "dark"],
+			originalAppearance
+		);
 		for (const appearance of appearances) {
-			const appearanceLabel = appearance === "automatic" ? `always match VS Code theme '${curVsCodeAppearance}'` : appearance;
+			const appearanceLabel =
+				appearance === "automatic"
+					? `always match VS Code theme '${curVsCodeAppearance}'`
+					: appearance;
 
 			availableOptions.push({
 				kind: QuickPickItemKind.Separator,
@@ -356,18 +389,15 @@ export class DrawioEditor {
 					onSelect: () => {
 						this.config.setTheme(theme);
 						this.config.setAppearance(appearance);
-					}
+					},
 				});
 			}
 		}
-		const result = await window.showQuickPick(
-			availableOptions,
-			{
-				onDidSelectItem: async (item) => {
-					(item as any).onSelect(true);
-				},
-			}
-		);
+		const result = await window.showQuickPick(availableOptions, {
+			onDidSelectItem: async (item) => {
+				(item as any).onSelect(true);
+			},
+		});
 		if (!result || !result.onSelect) {
 			await this.config.setTheme(originalTheme);
 			await this.config.setAppearance(originalAppearance);
@@ -378,7 +408,7 @@ export class DrawioEditor {
 }
 
 function withFirstUnique<T>(items: T[], firstItem: T): T[] {
-	const filtered = items.filter(t => t !== firstItem);
+	const filtered = items.filter((t) => t !== firstItem);
 	return [firstItem, ...filtered];
 }
 

--- a/src/utils/parseScale.ts
+++ b/src/utils/parseScale.ts
@@ -1,0 +1,8 @@
+/**
+ * Parses a user-provided PNG export scale/zoom factor.
+ * Returns `undefined` if the input is not a finite number greater than 0.
+ */
+export function parseScale(input: string): number | undefined {
+	const value = Number(input);
+	return Number.isFinite(value) && value > 0 ? value : undefined;
+}

--- a/test/DrawioClient/suite/DrawioClient.test.js
+++ b/test/DrawioClient/suite/DrawioClient.test.js
@@ -1,0 +1,99 @@
+const assert = require('assert');
+const { DrawioClient } = require('../../../out/DrawioClient/DrawioClient');
+
+class FakeMessageStream
+{
+  constructor()
+  {
+    this.sentMessages = [];
+    this.handler = null;
+  }
+
+  registerMessageHandler(handler)
+  {
+    this.handler = handler;
+    return { dispose() {} };
+  }
+
+  sendMessage(message)
+  {
+    this.sentMessages.push(JSON.parse(message));
+  }
+
+  respondToLastAction(event)
+  {
+    this.handler(JSON.stringify(event));
+  }
+}
+
+function createClient()
+{
+  const stream = new FakeMessageStream();
+  const client = new DrawioClient(stream, async () => ({}), () => {});
+  return { stream, client };
+}
+
+describe('DrawioClient', function ()
+{
+  describe('exportAsPngWithEmbeddedXml', function ()
+  {
+    it('sends the requested scale in the export action', async function ()
+    {
+      const { stream, client } = createClient();
+
+      const resultPromise = client.exportAsPngWithEmbeddedXml(3);
+
+      const sent = stream.sentMessages[stream.sentMessages.length - 1];
+      assert.strictEqual(sent.action, 'export');
+      assert.strictEqual(sent.format, 'xmlpng');
+      assert.strictEqual(sent.scale, 3);
+
+      stream.respondToLastAction({
+        event: 'export',
+        format: 'xmlpng',
+        data: 'data:image/png;base64,AAAA',
+        xml: '<mxfile/>',
+      });
+      await resultPromise;
+    });
+
+    it('omits scale when not specified', async function ()
+    {
+      const { stream, client } = createClient();
+
+      const resultPromise = client.exportAsPngWithEmbeddedXml();
+
+      const sent = stream.sentMessages[stream.sentMessages.length - 1];
+      assert.strictEqual('scale' in sent, false);
+
+      stream.respondToLastAction({
+        event: 'export',
+        format: 'xmlpng',
+        data: 'data:image/png;base64,AAAA',
+        xml: '<mxfile/>',
+      });
+      await resultPromise;
+    });
+  });
+
+  describe('export', function ()
+  {
+    it('forwards scale through to the png export', async function ()
+    {
+      const { stream, client } = createClient();
+
+      const resultPromise = client.export('diagram.png', 2);
+
+      const sent = stream.sentMessages[stream.sentMessages.length - 1];
+      assert.strictEqual(sent.scale, 2);
+
+      stream.respondToLastAction({
+        event: 'export',
+        format: 'xmlpng',
+        data: 'data:image/png;base64,AAAA',
+        xml: '<mxfile/>',
+      });
+      await resultPromise;
+    });
+  });
+});

--- a/test/utils/suite/parseScale.test.js
+++ b/test/utils/suite/parseScale.test.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+const { parseScale } = require('../../../out/utils/parseScale');
+
+describe('parseScale', function ()
+{
+  it('parses a plain positive integer', function ()
+  {
+    assert.strictEqual(parseScale('2'), 2);
+  });
+
+  it('parses a positive decimal', function ()
+  {
+    assert.strictEqual(parseScale('1.5'), 1.5);
+  });
+
+  it('returns undefined for zero', function ()
+  {
+    assert.strictEqual(parseScale('0'), undefined);
+  });
+
+  it('returns undefined for negative numbers', function ()
+  {
+    assert.strictEqual(parseScale('-2'), undefined);
+  });
+
+  it('returns undefined for non-numeric input', function ()
+  {
+    assert.strictEqual(parseScale('abc'), undefined);
+  });
+
+  it('returns undefined for empty string', function ()
+  {
+    assert.strictEqual(parseScale(''), undefined);
+  });
+
+  it('returns undefined for whitespace-only input', function ()
+  {
+    assert.strictEqual(parseScale('   '), undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #426. Exported PNGs looked blurry because the extension never
forwarded a zoom/scale factor to draw.io's embed `export` action, even
though the web app supports this (users can set zoom above 100% before
exporting there, but that option wasn't available in the extension).

The `Draw.io: Export` command now prompts for a scale factor (default
`1`) when exporting to `.png`, and forwards it through to draw.io.

## Changes

- `src/DrawioClient/DrawioTypes.ts` — add optional `scale` to the
  `export` action type.
- `src/DrawioClient/DrawioClient.ts` — `export()` and
  `exportAsPngWithEmbeddedXml()` accept and forward an optional
  `scale`.
- `src/DrawioEditorService.ts` — `handleExportCommand` asks for a
  scale via `showInputBox` when `.png` is chosen as the export target;
  `exportTo` forwards it to the client.
- `src/utils/parseScale.ts` (new) — small pure helper that parses/
  validates the scale input (rejects non-numeric, zero, negative, or
  blank values); reused for both input validation and the value sent
  to the export call.
- New unit tests: `test/DrawioClient/suite/DrawioClient.test.js`,
  `test/utils/suite/parseScale.test.js`.

## Testing performed

- Test-driven: wrote failing tests first for the `DrawioClient` scale
  plumbing and for `parseScale`, watched them fail for the expected
  reason, then implemented until green.
- Full unit suite (existing `test/inline-editor` tests + the new
  ones): **84/84 passing**, run via `npx mocha` directly.
  - Note: `mocha` and `@vscode/test-electron` aren't currently listed
    in `devDependencies`, so this repo's unit tests (including the
    pre-existing `test/inline-editor` suite) aren't wired into
    `yarn`/CI as-is. Ran them without modifying `package.json`.
- `tsc -p .` compiles clean for all files touched by this change
  (there are pre-existing `@types/mithril` errors unrelated to this
  PR, caused by a missing DOM lib in `tsconfig.json`).
- `prettier --check` passes on all changed files.
- Checked the `scale` parameter against the actual `jgraph/drawio`
  source (`EditorUi.js`, `data.action == 'export'` handler) rather
  than relying on documentation alone, to confirm it is genuinely
  forwarded into `exportToCanvas(...)` and controls the resolution of
  the rendered PNG.
- Built the extension locally (`yarn build`) into a `.vsix` to make
  manual verification possible.

## What has NOT been tested

**This change has not yet been manually verified inside a real VS
Code instance.** Nobody has installed the built `.vsix`, opened a
`.drawio` file, run `Draw.io: Export`, and confirmed the scale prompt
appears and actually produces a higher-resolution PNG end to end. All
verification so far is at the unit-test / source-code level; the
actual VS Code UI flow (the `showInputBox` prompt, the full export
round-trip) is unverified.

Planned manual QA (not yet executed):
- Export the same diagram at scale `1` and at scale `3`, compare
  output pixel dimensions/sharpness.
- Enter invalid input (`0`, `abc`) and confirm the validation message
  blocks the export.
- Confirm `.svg` and `.drawio` export still work unaffected (scale is
  only used for `.png`).

I'd like reviewers to help verify the in-editor behavior before this
is considered fully confirmed.