### PR TITLE
fix: correct spelling mistakes in documentation and liveshare plugin

### DIFF
--- a/docs/code-link.md
+++ b/docs/code-link.md
@@ -2,7 +2,7 @@
 
 The Code Link feature lets you link Draw.io nodes and edges to source code symbols.
 Just name a node or edge `#MySymbol` where `MySymbol` is the name of the symbol you want to link to.
-When code link is enabled (see the status bar) and you double click on a node or edge whith such a label, you will jump to the symbol definition.
+When code link is enabled (see the status bar) and you double click on a node or edge with such a label, you will jump to the symbol definition.
 
 ![](./demo-code-link.gif)
 
@@ -18,11 +18,11 @@ The Code Link Feature does not work on Github though.
 
 ![](./code-link-symbol-demo.gif)
 
-Code Link supports hierarchical document symbols. First, select the node, then navigate to the document and run the "Link Symbol With Selected Node" command. Select your symbol from the dropdown. This will link the node to a symbol as well as the current docment URI.
+Code Link supports hierarchical document symbols. First, select the node, then navigate to the document and run the "Link Symbol With Selected Node" command. Select your symbol from the dropdown. This will link the node to a symbol as well as the current document URI.
 
 Hierarchy levels are delimited by the dot "`.`" and you can choose to edit the paths by pressing "Ctrl+M" within the Draw.io editor.
 
-You can also run "Link Workspace Symbol With Selected Node" to link a symbol path without linking to the specific docment URI. This way, documents can be moved freely without breaking the code link. However, some symbol providers don't cooperate with exporting workspace symbols -- when this occurs, a warning will be shown.
+You can also run "Link Workspace Symbol With Selected Node" to link a symbol path without linking to the specific document URI. This way, documents can be moved freely without breaking the code link. However, some symbol providers don't cooperate with exporting workspace symbols -- when this occurs, a warning will be shown.
 
 ## Link Screenshots with Symbols
 

--- a/drawio-custom-plugins/src/liveshare.ts
+++ b/drawio-custom-plugins/src/liveshare.ts
@@ -46,7 +46,7 @@ Draw.loadPlugin((ui) => {
 
 		const cursors = new Set<Cursor>();
 		const rectangles = new Set<SelectionRectangle>();
-		const hightlights = new Highlights(graph);
+		const highlights = new Highlights(graph);
 
 		window.addEventListener("message", (evt) => {
 			if (evt.source !== window.opener) {
@@ -83,7 +83,7 @@ Draw.loadPlugin((ui) => {
 							highlightInfos.push({ cell, color: s.color });
 						}
 					}
-					hightlights.updateHighlights(highlightInfos);
+					highlights.updateHighlights(highlightInfos);
 
 					for (const c of rectangles) {
 						if (

--- a/package.json
+++ b/package.json
@@ -389,7 +389,7 @@
 							"properties": {
 								"entryId": {
 									"type": "string",
-									"description": "The id of the entry. A specfic entry can be enabled or deactivated in the editor."
+									"description": "The id of the entry. A specific entry can be enabled or deactivated in the editor."
 								},
 								"libName": {
 									"type": "string",


### PR DESCRIPTION
## Summary

Correct spelling mistakes in the extension configuration, Live Share plugin, and Code Link documentation.

## Changes

- Fix `specfic` to `specific` in the plugin configuration description
- Rename the `hightlights` variable to `highlights`
- Fix typos in the Code Link documentation